### PR TITLE
Feat/add to watchlist

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -59,7 +59,7 @@ async def watchlist_see_all(interaction: nextcord.Interaction):
     watchlist_file = open(WATCHLISTFILENAME, 'r')
     watchlist_data = json.load(watchlist_file)
     watchlist_file.close()
-    
+
     if len(watchlist_data["watchlists"]) == 0: #Respond if there are no watchlists
         response = "You have no watchlists right now, create a watchlist with /watchlist_create and you will see it here!"
     else:
@@ -73,6 +73,51 @@ async def watchlist_see_all(interaction: nextcord.Interaction):
                 for media in watchlist["media"]: #Print every media item
                     response += f"- {media}\n"
             response += "\n\n"
+
+    await interaction.response.send_message(response)
+
+
+
+
+@bot.slash_command(guild_ids=[GUILD_ID], name="watchlist_add", description="add a movie or show to a watchlist")
+async def watchlist_add(interaction: nextcord.Interaction, media_name, watchlist_name):
+
+    """
+    Adds a movie or show to a specified watchlist.
+
+    Parameters:
+    interaction (nextcord.Interaction): The interaction object representing the command invocation.
+    media_name (str): The name of the movie or show to be added.
+    watchlist_name (str): The name of the watchlist to which the movie or show will be added.
+
+    Returns:
+    None
+    """
+    # Read the JSON data
+    watchlist_file = open(WATCHLISTFILENAME, 'r')
+    watchlist_data = json.load(watchlist_file)
+    watchlist_file.close()
+
+    # Check if the watchlist exists
+    watchlist_exists = False
+    for watchlist in watchlist_data["watchlists"]:
+        if watchlist["name"] == watchlist_name:
+            watchlist_exists = True
+            # Check if media already exists in watchlist
+            if media_name not in watchlist["media"]:
+                watchlist["media"].append(media_name)
+                response = f"Added *{media_name}* to the **{watchlist_name}** watchlist!"
+            else:
+                response = f"*{media_name}* is already in the **{watchlist_name}** watchlist!"
+            break
+
+    if not watchlist_exists:
+        response = f"The **{watchlist_name}** watchlist does not exist! \nYou can create it with `/watchlist_create {watchlist_name}`"
+
+    # Write the updated JSON data
+    watchlist_file = open(WATCHLISTFILENAME, 'w')
+    watchlist_file.write(json.dumps(watchlist_data))
+    watchlist_file.close()
 
     await interaction.response.send_message(response)
 


### PR DESCRIPTION
Add functionality to add movies/shows (media) to specified watchlists
Duplicate media is not allowed (movies/shows with same name) in a watchlist
Handles if a specified watchlist doesn't exist
The command is
 ```/watchlist_add [media_name] [watchlist_name]```


Closes issues #14 