### PR TITLE
Feat/join watchlist

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,14 +109,27 @@ async def watchlist_join(interaction: nextcord.Interaction, watchlist_name):
     watchlist_data = json.load(watchlist_file)
     watchlist_file.close()
 
-    # Add participant to watchlist
-    print(interaction.user)
-    
+    #add participant to watchlist
+    user_id = interaction.user.id
+    found = 0
+    for watchlist in watchlist_data["watchlists"]:
+        if watchlist["name"] == watchlist_name:
+            found = 1
+            #check duplication
+            if (user_id in watchlist["participants"]):
+                response = "You are already in this watchlist."
+                break
+            else:
+                watchlist["participants"].append(user_id)
+                #write the change to json
+                watchlist_file = open(WATCHLISTFILENAME, 'w')
+                watchlist_file.write(json.dumps(watchlist_data))
+                watchlist_file.close()
+                response = f"You have joined the {watchlist_name} watchlist."
+                break
 
-    watchlist_file = open(WATCHLISTFILENAME, 'w')
-    watchlist_file.write(json.dumps(watchlist_data))
-    watchlist_file.close()
-    response = "Removed watchlist named."
+    if not found:
+        response = f"Watchlist named {watchlist_name} does not exist"
     await interaction.response.send_message(response)
 
 bot.run(BOT_TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -61,34 +61,34 @@ async def watchlist_see_all(interaction: nextcord.Interaction):
     await interaction.response.send_message(response)
 
 @bot.slash_command(guild_ids=[GUILD_ID], name="watchlist_create", description="create a new watchlist")
-async def watchlist_create(interaction: nextcord.Interaction, arg):
+async def watchlist_create(interaction: nextcord.Interaction, watchlist_name):
     #read the json to get all watchlist list
     watchlist_file = open(WATCHLISTFILENAME, 'r')
     watchlist_data = json.load(watchlist_file)
     watchlist_file.close()
 
     #write in the new watchlist to the json
-    watchlist_data["watchlists"].append({'name': arg, 'media': [], 'participants': []})
+    watchlist_data["watchlists"].append({'name': watchlist_name, 'media': [], 'participants': []})
     watchlist_file = open(WATCHLISTFILENAME, 'w')
     watchlist_file.write(json.dumps(watchlist_data))
     watchlist_file.close()
 
-    response = f"Created a new watchlist named {arg}. Add movies and shows to your new watchlist!"
+    response = f"Created a new watchlist named {watchlist_name}. Add movies and shows to your new watchlist!"
     await interaction.response.send_message(response)
 
 @bot.slash_command(guild_ids=[GUILD_ID], name="watchlist_delete", description="delete an existing watchlist")
-async def watchlist_delete(interaction: nextcord.Interaction, arg):
+async def watchlist_delete(interaction: nextcord.Interaction, watchlist_name):
     #read the json to get all watchlist list
     watchlist_file = open(WATCHLISTFILENAME, 'r')
     watchlist_data = json.load(watchlist_file)
     watchlist_file.close()
 
     if len(watchlist_data["watchlists"]) == 0:
-        response = f"Watchlist named {arg} does not exist."
+        response = f"Watchlist named {watchlist_name} does not exist."
     else:
         found = 0
         for i in range(len(watchlist_data)):
-            if watchlist_data["watchlists"][i]["name"] == arg:
+            if watchlist_data["watchlists"][i]["name"] == watchlist_name:
                 watchlist_data["watchlists"].pop(i)
                 found = 1
                 break
@@ -97,9 +97,9 @@ async def watchlist_delete(interaction: nextcord.Interaction, arg):
             watchlist_file = open(WATCHLISTFILENAME, 'w')
             watchlist_file.write(json.dumps(watchlist_data))
             watchlist_file.close()
-            response = f"Removed watchlist named {arg}."
+            response = f"Removed watchlist named {watchlist_name}."
         else: 
-            response = f"Watchlist named {arg} does not exist."
+            response = f"Watchlist named {watchlist_name} does not exist."
     await interaction.response.send_message(response)
 
 @bot.slash_command(guild_ids=[GUILD_ID], name="watchlist_join", description="join an existing watchlist")

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,7 @@ async def watchlist_create(interaction: nextcord.Interaction, arg):
     watchlist_file.close()
 
     #write in the new watchlist to the json
-    watchlist_data["watchlists"].append({'name': arg, 'media': []})
+    watchlist_data["watchlists"].append({'name': arg, 'media': [], 'participants': []})
     watchlist_file = open(WATCHLISTFILENAME, 'w')
     watchlist_file.write(json.dumps(watchlist_data))
     watchlist_file.close()
@@ -100,6 +100,23 @@ async def watchlist_delete(interaction: nextcord.Interaction, arg):
             response = f"Removed watchlist named {arg}."
         else: 
             response = f"Watchlist named {arg} does not exist."
+    await interaction.response.send_message(response)
+
+@bot.slash_command(guild_ids=[GUILD_ID], name="watchlist_join", description="join an existing watchlist")
+async def watchlist_join(interaction: nextcord.Interaction, watchlist_name):
+    #read the json to get all watchlist list
+    watchlist_file = open(WATCHLISTFILENAME, 'r')
+    watchlist_data = json.load(watchlist_file)
+    watchlist_file.close()
+
+    # Add participant to watchlist
+    print(interaction.user)
+    
+
+    watchlist_file = open(WATCHLISTFILENAME, 'w')
+    watchlist_file.write(json.dumps(watchlist_data))
+    watchlist_file.close()
+    response = "Removed watchlist named."
     await interaction.response.send_message(response)
 
 bot.run(BOT_TOKEN)

--- a/watchlist.json
+++ b/watchlist.json
@@ -1,1 +1,1 @@
-{"watchlists": [{"name": "hi", "media": [], "participants": []}]}
+{"watchlists": [{"name": "hi", "media": [], "participants": [310281830467108864]}]}

--- a/watchlist.json
+++ b/watchlist.json
@@ -1,1 +1,1 @@
-{"watchlists": [{"name": "hi", "media": [], "participants": [310281830467108864]}]}
+{"watchlists": []}

--- a/watchlist.json
+++ b/watchlist.json
@@ -1,1 +1,1 @@
-{"watchlists": []}
+{"watchlists": [{"name": "hi", "media": [], "participants": []}]}


### PR DESCRIPTION
Command `/watchlist_join [watchlist_name]` enrolls the user into the specified watchlist.
Detects duplications
Detects invalid watchlist names
Insensitive to different sessions

Added participants list for each watchlist in the json file, reflected by the change in watchlist_create command.
Replaced arguments called `arg` to `watchlist_name` in other command methods to improve user friendliness.

Closes #18 