### PR TITLE
Feat - clear media from a watchlist

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -212,7 +212,7 @@ async def watchlist_delete_media(interaction: nextcord.Interaction,
                                    media_name, watchlist_name):
     await delete_media(interaction, media_name, watchlist_name
                            )
-    
+
 # ---------------------------------------------------------------------------
 # Media Commands - Select a random media from watchlist
 # ---------------------------------------------------------------------------
@@ -237,13 +237,50 @@ async def watchlist_choose(interaction: nextcord.Interaction, watchlist_name):
             else:
                 selected_media = random.choice(watchlist["media"])
                 response = f"Let's watch **{selected_media}** \nTime to get out the popcorn!"
-            
+
 
     if not watchlist_exists:
         response = f"The **{watchlist_name}** watchlist does not exist! \nYou can create it with `/watchlist_create {watchlist_name}`"
 
     await interaction.response.send_message(response)
-    
+
+
+# ---------------------------------------------------------------------------
+# Media Commands - Clear a specified watchlist by removing all its media
+# ---------------------------------------------------------------------------
+
+@bot.slash_command(guild_ids=[GUILD_ID],
+                   name="watchlist_clear",
+                   description="remove all media from a watchlist")
+async def watchlist_clear(interaction: nextcord.Interaction, watchlist_name):
+
+    # Read the JSON data
+    watchlist_file = open(WATCHLISTFILENAME, 'r')
+    watchlist_data = json.load(watchlist_file)
+    watchlist_file.close()
+
+    # Find the watchlist
+    found = False
+    for watchlist in watchlist_data["watchlists"]:
+        if watchlist["name"] == watchlist_name:
+            found = True
+            if len(watchlist["media"]) == 0:
+                response = f"The **{watchlist_name}** watchlist is already empty."
+            else:
+                watchlist["media"] = []  # Clear the media list
+                response = f"Cleared all media from the **{watchlist_name}** watchlist."
+
+            # Write the updated JSON data
+            watchlist_file = open(WATCHLISTFILENAME, 'w')
+            watchlist_file.write(json.dumps(watchlist_data))
+            watchlist_file.close()
+            break
+
+    if not found:
+        response = f"Watchlist named {watchlist_name} does not exist."
+
+    await interaction.response.send_message(response)
+
 # ---------------------------------------------------------------------------
 # Participant Commands - Join, leave, view or notifty watchlist participants
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add functionality to delete all media from a specified watchlist
Handles if a watchlist doesn't exist
Handles if a watchlist already has no media

The command is
```/watchlist_clear [watchlist_name]```

Closes issues #16 