### PR TITLE
watchlist.json handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Project specific files
+watchlist.json

--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,6 @@ from dotenv import load_dotenv
 import nextcord
 from nextcord.ext import commands
 import random
-import json
 import utils
 # importing the other python files
 from commands import misc, media, watchlist, participant
@@ -27,6 +26,7 @@ EDIT_PERMISSION = 1024
 @bot.event
 async def on_ready():
     print(f'Logged in as {bot.user}')
+    utils.init_watchlist_json(WATCHLISTFILENAME)
 
 
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,13 @@
 import json
+import os
+
+# ---------------------------------------------------------------------------
+# A bunch of utility helper methods
+#   get_watchlist - Gets a specific watchlist given a name and returns it if it exists
+#   read_watchlist_file - Reads all the data from a watchlist if it exists and returns the data
+#   write_watchlist_file - Writes contents to a specified watchlist
+#   init_watchlistJSON - Creates a new watchlist.json file if it does not exist when the bot starts
+# ---------------------------------------------------------------------------
 def get_watchlist(watchlist_data, watchlist_name):
      for watchlist in watchlist_data["watchlists"]:
         if watchlist["name"] == watchlist_name:
@@ -15,3 +24,8 @@ def write_watchlist_file(watchlist_file_name, watchlist_data):
     watchlist_file = open(watchlist_file_name, 'w')
     watchlist_file.write(json.dumps(watchlist_data))
     watchlist_file.close()
+
+def init_watchlist_json(watchlist_file_name):
+    if not os.path.exists(watchlist_file_name):
+        with open(watchlist_file_name, 'w') as file:
+            json.dump({"watchlists": []}, file)

--- a/watchlist.json
+++ b/watchlist.json
@@ -1,1 +1,0 @@
-{"watchlists": []}


### PR DESCRIPTION
watchlist.json is now in .gitignore so it does not need to be pushed to the repo constantly, it will now be generated automatically if it does not already exist.

closes #81 